### PR TITLE
chore: bump requests to 2.33.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ flake8~=7.1.1
 flake8-bugbear~=24.10.31
 flake8-black~=0.3.6
 black~=26.3.1
-requests~=2.32.5
+requests~=2.33.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pull request updates the `requests` dependency in `requirements.txt` from `~=2.32.5` to `~=2.33.1`, matching the existing compatible-release pinning style used in this file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09d5e078-472a-4393-9f36-2cc538f7a381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09d5e078-472a-4393-9f36-2cc538f7a381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

